### PR TITLE
fix invalid word

### DIFF
--- a/de-2048-v1.txt
+++ b/de-2048-v1.txt
@@ -569,7 +569,7 @@ fahrrad
 faktor
 falke
 fallen
-FALSE
+falsch
 falter
 familie
 fangen


### PR DESCRIPTION
falsch wurde beim kopieren durch FALSE ersetzt und ist in der BIP39 wordlist gelandet

wir benutzen die (korrigierte) Wordlist im [CardanoSharp.Wallet](https://github.com/CardanoSharp/cardanosharp-wallet) projekt 